### PR TITLE
fix: Mapping of http status to OutSystems

### DIFF
--- a/packages/outsystems-wrapper/dist/outsystems-wrapper/src/index.d.ts
+++ b/packages/outsystems-wrapper/dist/outsystems-wrapper/src/index.d.ts
@@ -7,6 +7,13 @@ declare class OSFileTransferWrapper {
     private handleBasicFileInfo;
     uploadFile(options: any, scope: any): void;
     private handleTransferFinished;
+    /**
+     * Converts the error with the correct properties that OutSystems expects in FileTransferError structure.
+     * This is done here to have the same fields as the old cordova plugin - thus ensuring backwards compatibility.
+     * @param error the error coming from the plugin
+     * @returns The error with the properties that OutSystems expects
+     */
+    private convertError;
     private isPWA;
     private isCapacitorPluginDefined;
     /**

--- a/packages/outsystems-wrapper/dist/outsystems.cjs
+++ b/packages/outsystems-wrapper/dist/outsystems.cjs
@@ -176,7 +176,7 @@ class OSFileTransferWrapper {
     };
     const downloadError = (err) => {
       if (scope.downloadCallback && scope.downloadCallback.downloadError) {
-        scope.downloadCallback.downloadError(err);
+        scope.downloadCallback.downloadError(this.convertError(err));
       }
       this.handleTransferFinished();
     };
@@ -235,7 +235,7 @@ class OSFileTransferWrapper {
     };
     const uploadError = (err) => {
       if (scope.uploadCallback && scope.uploadCallback.uploadError) {
-        scope.uploadCallback.uploadError(err);
+        scope.uploadCallback.uploadError(this.convertError(err));
       }
       this.handleTransferFinished();
     };
@@ -268,6 +268,18 @@ class OSFileTransferWrapper {
         Capacitor.Plugins.FileTransfer.removeAllListeners();
       }
     }
+  }
+  /**
+   * Converts the error with the correct properties that OutSystems expects in FileTransferError structure.
+   * This is done here to have the same fields as the old cordova plugin - thus ensuring backwards compatibility.
+   * @param error the error coming from the plugin
+   * @returns The error with the properties that OutSystems expects
+   */
+  convertError(error) {
+    return {
+      ...error,
+      http_status: error.httpStatus
+    };
   }
   isPWA() {
     if (this.isSynapseDefined()) {

--- a/packages/outsystems-wrapper/dist/outsystems.js
+++ b/packages/outsystems-wrapper/dist/outsystems.js
@@ -178,7 +178,7 @@
       };
       const downloadError = (err) => {
         if (scope.downloadCallback && scope.downloadCallback.downloadError) {
-          scope.downloadCallback.downloadError(err);
+          scope.downloadCallback.downloadError(this.convertError(err));
         }
         this.handleTransferFinished();
       };
@@ -237,7 +237,7 @@
       };
       const uploadError = (err) => {
         if (scope.uploadCallback && scope.uploadCallback.uploadError) {
-          scope.uploadCallback.uploadError(err);
+          scope.uploadCallback.uploadError(this.convertError(err));
         }
         this.handleTransferFinished();
       };
@@ -270,6 +270,18 @@
           Capacitor.Plugins.FileTransfer.removeAllListeners();
         }
       }
+    }
+    /**
+     * Converts the error with the correct properties that OutSystems expects in FileTransferError structure.
+     * This is done here to have the same fields as the old cordova plugin - thus ensuring backwards compatibility.
+     * @param error the error coming from the plugin
+     * @returns The error with the properties that OutSystems expects
+     */
+    convertError(error) {
+      return {
+        ...error,
+        http_status: error.httpStatus
+      };
     }
     isPWA() {
       if (this.isSynapseDefined()) {

--- a/packages/outsystems-wrapper/dist/outsystems.mjs
+++ b/packages/outsystems-wrapper/dist/outsystems.mjs
@@ -174,7 +174,7 @@ class OSFileTransferWrapper {
     };
     const downloadError = (err) => {
       if (scope.downloadCallback && scope.downloadCallback.downloadError) {
-        scope.downloadCallback.downloadError(err);
+        scope.downloadCallback.downloadError(this.convertError(err));
       }
       this.handleTransferFinished();
     };
@@ -233,7 +233,7 @@ class OSFileTransferWrapper {
     };
     const uploadError = (err) => {
       if (scope.uploadCallback && scope.uploadCallback.uploadError) {
-        scope.uploadCallback.uploadError(err);
+        scope.uploadCallback.uploadError(this.convertError(err));
       }
       this.handleTransferFinished();
     };
@@ -266,6 +266,18 @@ class OSFileTransferWrapper {
         Capacitor.Plugins.FileTransfer.removeAllListeners();
       }
     }
+  }
+  /**
+   * Converts the error with the correct properties that OutSystems expects in FileTransferError structure.
+   * This is done here to have the same fields as the old cordova plugin - thus ensuring backwards compatibility.
+   * @param error the error coming from the plugin
+   * @returns The error with the properties that OutSystems expects
+   */
+  convertError(error) {
+    return {
+      ...error,
+      http_status: error.httpStatus
+    };
   }
   isPWA() {
     if (this.isSynapseDefined()) {

--- a/packages/outsystems-wrapper/src/index.ts
+++ b/packages/outsystems-wrapper/src/index.ts
@@ -39,7 +39,7 @@ class OSFileTransferWrapper {
         
         const downloadError = (err: FileTransferError) => {
             if (scope.downloadCallback && scope.downloadCallback.downloadError) {
-                scope.downloadCallback.downloadError(err);
+                scope.downloadCallback.downloadError(this.convertError(err));
             }
             this.handleTransferFinished();
         };
@@ -116,7 +116,7 @@ class OSFileTransferWrapper {
         
         const uploadError = (err: FileTransferError) => {
             if (scope.uploadCallback && scope.uploadCallback.uploadError) {
-                scope.uploadCallback.uploadError(err);
+                scope.uploadCallback.uploadError(this.convertError(err));
             }
             this.handleTransferFinished();
         };
@@ -162,6 +162,19 @@ class OSFileTransferWrapper {
                 Capacitor.Plugins.FileTransfer.removeAllListeners();
             }
         }
+    }
+
+    /**
+     * Converts the error with the correct properties that OutSystems expects in FileTransferError structure.
+     * This is done here to have the same fields as the old cordova plugin - thus ensuring backwards compatibility.
+     * @param error the error coming from the plugin
+     * @returns The error with the properties that OutSystems expects
+     */
+    private convertError(error: FileTransferError): FileTransferError & { http_status?: number } {
+        return {
+            ...error,
+            http_status: error.httpStatus,
+        };
     }
     
     private isPWA(): boolean {


### PR DESCRIPTION
The old cordova plugin, and PWA code, return the HTTP Status code (whenever present) as `http_status`, which is the JSON key that is expected by `FileTransferError` structure in OutSystems.

Now, the new cordova (and capacitor plugin) return it as `httpStatus`, and it makes more sense to use camel case. However, to make sure OutSystems Apps continue to work with new and old plugins, and to not make changes on native side, the easiest way was to modify what is being returned by the new plugins, to include `http_status`.

