### PR TITLE
fix: Set native lib as @aar

### DIFF
--- a/packages/cordova-plugin/android/build.gradle
+++ b/packages/cordova-plugin/android/build.gradle
@@ -17,7 +17,7 @@ allprojects {
 
 dependencies{
     // TODO replace with 1.0.0 once an official release of the native library is done
-    implementation "io.ionic.libs:ionfiletransfer-android:0.0.1-dev-3"
+    implementation "io.ionic.libs:ionfiletransfer-android:0.0.1-dev-3@aar"
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
     implementation("com.github.outsystems:oscordova-android:2.0.1@aar")


### PR DESCRIPTION
When using this plugins in OutSystems with MABS 10, we were getting a build error where the nativelib had a dependency that required compileSdk 35, but MABS 10 uses 34.

Because the native lib doesn't really need specific versions of a dependency, and to make sure the plugin works regardless of the low-code's android compileSdk, we unbundle the dependencies of the native lib by using @aar, which is what we usually have on other cordova plugins.