### PR TITLE
fix: converting error for cordova and capacitor

### DIFF
--- a/packages/outsystems-wrapper/dist/outsystems.cjs
+++ b/packages/outsystems-wrapper/dist/outsystems.cjs
@@ -276,10 +276,17 @@ class OSFileTransferWrapper {
    * @returns The error with the properties that OutSystems expects
    */
   convertError(error) {
-    return {
-      ...error,
-      http_status: error.httpStatus
-    };
+    if (error.data) {
+      return {
+        ...error.data,
+        http_status: error.data.httpStatus
+      };
+    } else {
+      return {
+        ...error,
+        http_status: error.httpStatus
+      };
+    }
   }
   isPWA() {
     if (this.isSynapseDefined()) {

--- a/packages/outsystems-wrapper/dist/outsystems.js
+++ b/packages/outsystems-wrapper/dist/outsystems.js
@@ -278,10 +278,17 @@
      * @returns The error with the properties that OutSystems expects
      */
     convertError(error) {
-      return {
-        ...error,
-        http_status: error.httpStatus
-      };
+      if (error.data) {
+        return {
+          ...error.data,
+          http_status: error.data.httpStatus
+        };
+      } else {
+        return {
+          ...error,
+          http_status: error.httpStatus
+        };
+      }
     }
     isPWA() {
       if (this.isSynapseDefined()) {

--- a/packages/outsystems-wrapper/dist/outsystems.mjs
+++ b/packages/outsystems-wrapper/dist/outsystems.mjs
@@ -274,10 +274,17 @@ class OSFileTransferWrapper {
    * @returns The error with the properties that OutSystems expects
    */
   convertError(error) {
-    return {
-      ...error,
-      http_status: error.httpStatus
-    };
+    if (error.data) {
+      return {
+        ...error.data,
+        http_status: error.data.httpStatus
+      };
+    } else {
+      return {
+        ...error,
+        http_status: error.httpStatus
+      };
+    }
   }
   isPWA() {
     if (this.isSynapseDefined()) {

--- a/packages/outsystems-wrapper/src/index.ts
+++ b/packages/outsystems-wrapper/src/index.ts
@@ -170,11 +170,20 @@ class OSFileTransferWrapper {
      * @param error the error coming from the plugin
      * @returns The error with the properties that OutSystems expects
      */
-    private convertError(error: FileTransferError): FileTransferError & { http_status?: number } {
-        return {
-            ...error,
-            http_status: error.httpStatus,
-        };
+    private convertError(error: any): FileTransferError & { http_status?: number } {
+        if (error.data) {
+            // for Capacitor - when there is extra data, it is returned in a separate data attribute
+            return {
+                ...error.data,
+                http_status: error.data.httpStatus,
+            };
+        } else {
+            // for Cordova
+            return {
+                ...error,
+                http_status: error.httpStatus,
+            };
+        }
     }
     
     private isPWA(): boolean {


### PR DESCRIPTION
The `FileTransferError` returned by Capacitor is different than the expected structure in the Outsystems wrapper. Additional attributes go in a `data` parameter. As such, we adapt the error conversion logic to use `data` if present.