### PR TITLE
fix(ios): update to library framework built with Xcode 16 and not 26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.5]
+
+### 2026-03-09
+
+### Fixes
+
+- **ios** Update to verison of IONFileTransferLib built with Xcode 16 (version 1.0.3).
+
 ## [1.0.4]
 
 ### 2026-02-03

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.outsystems.plugins.filetransfer",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "private": true,
   "dependencies": {},
   "scripts": {

--- a/packages/cordova-plugin/package.json
+++ b/packages/cordova-plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.outsystems.plugins.filetransfer",
   "displayName": "FileTransfer",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "File transfer plugin for Cordova",
   "scripts": {
     "lint": "npm run eslint && npm run prettier -- --check",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="com.outsystems.plugins.filetransfer" version="1.0.4" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="com.outsystems.plugins.filetransfer" version="1.0.5" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>OSFileTransfer</name>
     <description>OutSystems' cordova file transfer plugin for mobile apps.</description>
     <author>OutSystems Inc</author>
@@ -45,7 +45,7 @@
                 <source url="https://cdn.cocoapods.org/"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="IONFileTransferLib" spec="1.0.2" />
+                <pod name="IONFileTransferLib" spec="1.0.3" />
             </pods>
         </podspec>
     


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- We should use a version of the framework built with Xcode 16 to keep support with apps built with Xcode 16.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

MABS 11.2 build working: https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=590592ebe92f4f7f86f39ac7023d599db41fcdd1&stg=dev

MABS 12 build working: https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=b222db44aff0a2d33d1ef520267a081970438364&stg=dev

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
