### PR TITLE
chore(android): Remove custom maven repo

### DIFF
--- a/packages/cordova-plugin/android/build.gradle
+++ b/packages/cordova-plugin/android/build.gradle
@@ -9,12 +9,6 @@ buildscript {
     }
 }
 
-allprojects {
-    repositories {
-        maven { url 'https://pkgs.dev.azure.com/OutSystemsRD/9e79bc5b-69b2-4476-9ca5-d67594972a52/_packaging/PublicArtifactRepository/maven/v1' }
-    }
-}
-
 dependencies{
     implementation "io.ionic.libs:ionfiletransfer-android:1.0.3@aar"
     implementation fileTree(dir: 'libs', include: ['*.jar'])


### PR DESCRIPTION
The repo isn't necessary for this plugin (native library available in Maven Central), so this PR removes it.

For more context see https://github.com/ionic-team/cordova-outsystems-file/pull/24